### PR TITLE
Update nlu-based-item-search.ipynb to fix errors

### DIFF
--- a/nlu-based-item-search.ipynb
+++ b/nlu-based-item-search.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "In this notebook, we'll build the core components of a textually similar item search. Often people don't know what exactly they are looking for and in that case they just type an item description and hope it will retrieve similar items.\n",
     "\n",
-    "One of the core components of textually similar items search is a fixed length sentence/word embedding i.e. a  “feature vector” that corresponds to that text. The reference word/sentence embedding typically are generated offline and must be stored so they can be efficiently searched. Generating word/sentence embeddings can be achieved using pretrained language models such as BERT (Bidirectional Encoder Representations from Transformers). In our use case we are using a pretrained BERT model from sentence-transformers(https://github.com/UKPLab/sentence-transformers).\n",
+    "One of the core components of textually similar items search is a fixed length sentence/word embedding i.e. a  “feature vector” that corresponds to that text. The reference word/sentence embedding typically are generated offline and must be stored so they can be efficiently searched. Generating word/sentence embeddings can be achieved using pretrained language models such as BERT (Bidirectional Encoder Representations from Transformers). In our use case we are using a pretrained BERT model from [HuggingFace Transformers](https://huggingface.co/sentence-transformers/distilbert-base-nli-stsb-mean-tokens).\n",
     "\n",
     "To enable efficient searches for textually similar items, we'll use Amazon SageMaker to generate fixed length sentence embeddings i.e “feature vectors” and use the K-Nearest Neighbor (KNN) algorithm in Amazon Elasticsearch service. KNN for Amazon Elasticsearch Service7.7 lets you search for points in vector space and find the \"nearest neighbors\" for those points by cosine similarity (Default is Euclidean distance). Use cases include recommendations (for example, an \"other songs you might like\" feature in a music application), image recognition, and fraud detection.\n",
     "\n",
@@ -45,15 +45,36 @@
     "!pip install tqdm\n",
     "\n",
     "#install necessary pkg to make connection with elasticsearch domain\n",
-    "!pip install elasticsearch\n",
+    "!pip install \"elasticsearch<7.14.0\"\n",
     "!pip install requests\n",
     "!pip install requests-aws4auth\n",
-    "!pip install \"sagemaker<2.0\" --force-reinstall"
+    "!pip install sagemaker -U"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you run this notebook in SageMaker Studio, you need to make sure `ipywidgets` is installed and restart the kernel, so please uncomment the code in the next cell, and run it.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%capture\n",
+    "# import IPython\n",
+    "# import sys\n",
+    "\n",
+    "# !{sys.executable} -m pip install ipywidgets\n",
+    "# IPython.Application.instance().kernel.do_shutdown(True)  # has to restart kernel so changes are used"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +87,9 @@
     "role = get_execution_role()\n",
     "\n",
     "s3_resource = boto3.resource(\"s3\")\n",
-    "s3 = boto3.client('s3')"
+    "s3 = boto3.client('s3')\n",
+    "\n",
+    "print(f'SageMaker SDK Version: {sagemaker.__version__}')"
    ]
   },
   {
@@ -207,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +263,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# we are using realtime traslation which will take around ~15 min. \n",
+    "# we are using realtime traslation which will take around ~25 min. \n",
     "workers = 1 * cpu_count()\n",
     "\n",
     "#downloading images to local disk\n",
@@ -249,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +287,7 @@
    "source": [
     "## SageMaker Model Hosting\n",
     "\n",
-    "In this section will host the pretrained BERT model into SageMaker Pytorch model server to generate 768x1 dimension fixed length sentence embedding from sentence-transformers (https://github.com/UKPLab/sentence-transformers). \n",
+    "In this section will host the pretrained BERT model into SageMaker Pytorch model server to generate 768x1 dimension fixed length sentence embedding from [sentence-transformers](https://github.com/UKPLab/sentence-transformers) using [HuggingFace Transformers](https://huggingface.co/sentence-transformers/distilbert-base-nli-stsb-mean-tokens). \n",
     "\n",
     "**Citation:** <br>\n",
     "    @inproceedings{reimers-2019-sentence-bert,<br>\n",
@@ -286,33 +309,7 @@
    },
    "outputs": [],
    "source": [
-    "# !pip install sentence-transformers\n",
     "!pip install transformers"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# create tar.gz model file\n",
-    "# this saves a config and model file to a directory \n",
-    "\n",
-    "model.save_pretrained('transformer_model')\n",
-    "!cp transformer_model/pytorch_model.bin model.pth\n",
-    "!cp transformer_model/config.json transformer_endpoint/config.json\n",
-    "\n",
-    "#zip the model .gz format\n",
-    "import tarfile\n",
-    "export_dir = 'model.pth'\n",
-    "with tarfile.open('models/model.tar.gz', mode='w:gz') as archive:\n",
-    "    archive.add(export_dir, recursive=False)\n",
-    "    \n",
-    "!rm model.pth\n",
-    "\n",
-    "# send model to s3\n",
-    "inputs = sagemaker_session.upload_data(path='models/model.tar.gz', bucket=bucket, key_prefix='transformer_models')"
    ]
   },
   {
@@ -324,22 +321,19 @@
    "outputs": [],
    "source": [
     "#Save the model to disk which we will host at sagemaker\n",
-    "# from sentence_transformers import models, SentenceTransformer\n",
     "from transformers import AutoTokenizer, AutoModel\n",
     "saved_model_dir = 'transformer'\n",
     "os.makedirs(saved_model_dir, exist_ok=True)\n",
     "\n",
-    "# model = SentenceTransformer('distilbert-base-nli-stsb-mean-tokens')\n",
     "tokenizer = AutoTokenizer.from_pretrained(\"sentence-transformers/distilbert-base-nli-stsb-mean-tokens\")\n",
     "model = AutoModel.from_pretrained(\"sentence-transformers/distilbert-base-nli-stsb-mean-tokens\") \n",
     "\n",
-    "# model.save(saved_model_dir)\n",
     "model.save_pretrained(saved_model_dir)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,7 +344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -360,7 +354,7 @@
     "#zip the model .gz format\n",
     "import tarfile\n",
     "export_dir = 'model.pth'\n",
-    "with tarfile.open('models/model.tar.gz', mode='w:gz') as archive:\n",
+    "with tarfile.open('model.tar.gz', mode='w:gz') as archive:\n",
     "    archive.add(export_dir, recursive=False)\n",
     "    \n",
     "!rm model.pth"
@@ -374,7 +368,7 @@
    "source": [
     "#Upload the model to S3\n",
     "\n",
-    "inputs = sagemaker_session.upload_data(path='models/model.tar.gz', key_prefix='model')\n",
+    "inputs = sagemaker_session.upload_data(path='model.tar.gz', key_prefix='sentence-transformers-model')\n",
     "inputs"
    ]
   },
@@ -384,20 +378,20 @@
    "source": [
     "First we need to create a PyTorchModel object. The deploy() method on the model object creates an endpoint which serves prediction requests in real-time. If the instance_type is set to a SageMaker instance type (e.g. ml.m5.large) then the model will be deployed on SageMaker. If the instance_type parameter is set to *__local__* then it will be deployed locally as a Docker container and ready for testing locally.\n",
     "\n",
-    "First we need to create a RealTimePredictor class to accept TEXT as input and output JSON. The default behaviour is to accept a numpy array."
+    "First we need to create a [`Predictor`](https://sagemaker.readthedocs.io/en/stable/api/inference/predictors.html) class to accept TEXT as input and output JSON. The default behaviour is to accept a numpy array."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from sagemaker.pytorch import PyTorch, PyTorchModel\n",
-    "from sagemaker.predictor import RealTimePredictor\n",
+    "from sagemaker.predictor import Predictor\n",
     "from sagemaker import get_execution_role\n",
     "\n",
-    "class StringPredictor(RealTimePredictor):\n",
+    "class StringPredictor(Predictor):\n",
     "    def __init__(self, endpoint_name, sagemaker_session):\n",
     "        super(StringPredictor, self).__init__(endpoint_name, sagemaker_session, content_type='text/plain')\n",
     "           "
@@ -417,14 +411,16 @@
     "                             framework_version = '1.7.1',\n",
     "                             predictor_cls=StringPredictor)\n",
     "\n",
-    "predictor = pytorch_model.deploy(instance_type='ml.m5.large', initial_instance_count=1, endpoint_name = f'nlu-search-model-{int(time.time())}')\n"
+    "predictor = pytorch_model.deploy(instance_type='ml.m5.large', \n",
+    "                                 initial_instance_count=1, \n",
+    "                                 endpoint_name = f'nlu-search-model-{int(time.time())}')\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "sentence transformers uses BERT pretrained model so it will generate 768 dimension for the given text. we will quickly validate the same in next cell."
+    "HuggingFace Transformers uses BERT pretrained model so it will generate 768 dimension for the given text. we will quickly validate the same in next cell."
    ]
   },
   {
@@ -457,7 +453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -480,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -525,6 +521,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# If you need to load zalando-translated-data.json execute the following code\n",
+    "with open('zalando-translated-data.json') as json_file:\n",
+    "    results = json.load(json_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "results[0]['descriptions']"
    ]
   },
@@ -557,7 +564,7 @@
    "outputs": [],
    "source": [
     "# defining a function to import the feature vectors corrosponds to each S3 URI into Elasticsearch KNN index\n",
-    "# This process will take around ~10 min.\n",
+    "# This process will take around ~25 min.\n",
     "\n",
     "def es_import(concat_result):\n",
     "    vector = json.loads(predictor.predict(concat_result['descriptions']))\n",
@@ -792,7 +799,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -940,9 +947,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "conda_pytorch_latest_p36",
    "language": "python",
-   "name": "conda_python3"
+   "name": "conda_pytorch_latest_p36"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
*Issue #, if available:*
- `NameError: name 'model' is not defined` error were running the SageMaker Model Hosting part.
- `Elasticsearch::UnsupportedProductError (The client noticed that the server is not a supported distribution of Elasticsearch` error were creating the "idx_zalando" index.
- `sagemaker.predictor.RealTimePredictor has been renamed` warning.

*Description of changes:*
- Fixed `NameError: name 'model' is not defined` error.
- Fixed `Elasticsearch::UnsupportedProductError (The client noticed that the server is not a supported distribution of Elasticsearch` error were creating the "idx_zalando" index.
- Added code to install ipywidgets to enable running the notebook on SageMaker Studio.
- Added optional code to load `zalando-translated-data.json` if needed.
- Upgraded notebook to use SageMaker SDK v2.0 - fixed `sagemaker.predictor.RealTimePredictor has been renamed` warning by using `Predictor`.
- Updated cells markup to reflect that we are using HuggingFace Transformers model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
